### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ After Effects
 CSS
 ![CSS-Bezier](images/css-bezier.png)
 
-Below shows how the timeline above would look in CSS. Curve A & B are custom `cubic-bezier()` created with tools like [Ceasar](http://matthewlein.com/ceaser/) or [Cubic-Bezier.com](http://cubic-bezier.com/). Its important to take note that the easing curve is defined in the percentage value before you want the ease to happen. 
+Below shows how the timeline above would look in CSS. Curve A & B are custom `cubic-bezier()` created with tools like [Caesar](http://matthewlein.com/ceaser/) or [Cubic-Bezier.com](http://cubic-bezier.com/). Its important to take note that the easing curve is defined in the percentage value before you want the ease to happen. 
 
 
 	@keyframes ae-to-css {


### PR DESCRIPTION
ryanbrownhill, I've corrected a typographical error in the documentation of the [ae-css](https://github.com/ryanbrownhill/ae-css) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
